### PR TITLE
Is this "onDraw()->invalidate()->onDraw-> ..." loop happening too soon?

### DIFF
--- a/lib/src/main/java/com/github/ndczz/infinityloading/InfinityLoading.java
+++ b/lib/src/main/java/com/github/ndczz/infinityloading/InfinityLoading.java
@@ -153,8 +153,16 @@ public class InfinityLoading extends View {
         canvas.drawCircle(progressStartCoords[0], progressStartCoords[1], strokeWidth / 2, progressEndPaint);
         canvas.drawCircle(progressEndCoords[0], progressEndCoords[1], strokeWidth / 2, progressEndPaint);
 
-        invalidate();
+        handler.sendEmptyMessageDelayed(11, 10);
     }
+
+    private Handler handler = new Handler(){
+        @Override
+        public void handleMessage(Message msg) {
+            invalidate();
+        }
+    };  
+      
 
     private void updateProgress() {
         progressPath.reset();


### PR DESCRIPTION
onDraw() called invalidate(). And invalidate() will make onDraw() be called later. This is a loop that happens too quick.

---

"Profile GPU Rendering" :
Google says "If this orange bar is getting large, then it means that you’re doing a lot of work on the GPU resulting from many complex views that require a lot of OpenGL rendering commands to be processed."

![before](https://cloud.githubusercontent.com/assets/1705831/12695649/c6947fdc-c78f-11e5-882e-93b7c9528809.jpg)

---

I called invalidate() after 10ms, to make CPU have some time to rest. Using the "Profile GPU Rendering", the orange line is reduced.

![after10](https://cloud.githubusercontent.com/assets/1705831/12695650/cf2201e2-c78f-11e5-8e10-8efe26a4b573.jpg)
